### PR TITLE
Fix typo: eefect->effect, thefore->therefore

### DIFF
--- a/chapter_cpu_schedules/arch.md
+++ b/chapter_cpu_schedules/arch.md
@@ -86,8 +86,8 @@ as 2 logical cores to the operating system. So even the system shows there are 1
 cores, physically our CPU only has 8 cores.
 
 Having two threads sharing the resource of the same core may increase the total throughput but at the expense of increasing the overall lantency.
-In addition the eefect of hyper-threading is very much dependent on the application.
-Thefore, it is not generally recommended to leverage hyper-threading in the deep learning workloads.
+In addition the effect of hyper-threading is very much dependent on the application.
+Therefore, it is not generally recommended to leverage hyper-threading in the deep learning workloads.
 Later on in the book, you'll see that we only launch 8 threads even if our CPU presents 16 cores.
 
 ### Performance

--- a/chapter_cpu_schedules/vector_add.md
+++ b/chapter_cpu_schedules/vector_add.md
@@ -114,7 +114,7 @@ When the vector size is small, the default scheduling outperforms NumPy, which m
 
 ## Parallelization
 
-One important optimization that is not enabled by default is thread-level arallelization. The vector addition operator is an [embarrassingly parallel workload](https://en.wikipedia.org/wiki/Embarrassingly_parallel), we can just change the for-loop into a parallel for-loop. In TVM, we first obtain the scheduler for the output symbol `C` by `s[C]`, and then impose the parallelization of the computation to its first axis, which is `C.op.axis[0]`.
+One important optimization that is not enabled by default is thread-level parallelization. The vector addition operator is an [embarrassingly parallel workload](https://en.wikipedia.org/wiki/Embarrassingly_parallel), we can just change the for-loop into a parallel for-loop. In TVM, we first obtain the scheduler for the output symbol `C` by `s[C]`, and then impose the parallelization of the computation to its first axis, which is `C.op.axis[0]`.
 
 ```{.python .input  n=7}
 def parallel(n):


### PR DESCRIPTION
Hi, there.

I fix the typo: `eefect->effect, thefore->therefore` in `chapter_cpu_schedules/arch.md`.